### PR TITLE
Add parenthesis on if-statements

### DIFF
--- a/notifyslack.js
+++ b/notifyslack.js
@@ -77,8 +77,9 @@ app.get('/', function (req, res) {
 app.get('/auth', function (req, res) {
 	
 	// once an auth key is set bail
-	if (settings.oauth_token)
+	if (settings.oauth_token) {
 		res.redirect('/'); return;
+	}
 
 	console.log(authorization_uri);
 	res.redirect(authorization_uri);
@@ -89,8 +90,9 @@ app.get('/auth', function (req, res) {
 app.get('/callback', function (req, res) {
 
 	// once an auth key is set bail
-	if (settings.oauth_token)
+	if (settings.oauth_token) {
 		res.redirect('/'); return;
+	}
 
 	var code = req.query.code;
 	console.log('/callback');


### PR DESCRIPTION
Missing parenthesis on if-statements causing timeout errors on Heroku.

cc @scottsweb 